### PR TITLE
Change st.divider() to st.markdown(---)

### DIFF
--- a/streamlitui.py
+++ b/streamlitui.py
@@ -82,7 +82,7 @@ def main():
     display_messages()
     st.text_input("Message", key="user_input", disabled=not is_openai_api_key_set(), on_change=process_input)
 
-    st.divider()
+    st.markdown("---")
     st.markdown("Source code: [Github](https://github.com/Anil-matcha/ChatPDF)")
 
 


### PR DESCRIPTION
It seems like you're having a problem with the `st.divider()` function in your Streamlit app, but there's no specific error message provided.



![Screenshot 2023-06-04 at 7 26 24 AM](https://github.com/Anil-matcha/ChatPDF/assets/485547/5fb4a170-ee19-49a0-972c-537c56def6a6)

solution: Change `st.divider()` to `st.markdown("---")` and this error goes away

